### PR TITLE
Use https for map source/license links

### DIFF
--- a/visualizations/kentik-map/index.js
+++ b/visualizations/kentik-map/index.js
@@ -20,7 +20,7 @@ import { getCountryMapData } from './getMapData';
 const mapTiles =
   'https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png';
 const mapAttr =
-  'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.';
+  'Map tiles by <a href="https://stamen.com">Stamen Design</a>, under <a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="https://openstreetmap.org">OpenStreetMap</a>, under <a href="https://www.openstreetmap.org/copyright">ODbL</a>.';
 
 // these don't work because the component is getting passed null for its prop values... and nr1.json doesn't support default values
 const defaultProps = {


### PR DESCRIPTION
This was identified as a medium risk vulnerability (details of the finding below):

Insecure HTTP links must not be used. An attacker can perform manipulator-in-the-middle attacks when a user clicks on the insecure links.

This is low likelihood as an attacker needs to be able to perform other attacks to exploit this vulnerability. For example, the attacker needs to be able to perform 
DNS redirection, etc. In certain networks, this is not extremely difficult to perform using DNS Poisoning or ARP Poisoning attacks.